### PR TITLE
Fix SSR prerender style mismatches

### DIFF
--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -28,7 +28,7 @@ const getData = () => {
 export default function Page() {
   const modalTitle = 'Add Question';
   const [questionList, setQuestionList] = useState<QuestionRowData[]>([]);
-  const [added, setAdded] = useState(true);
+  const [loading, setLoading] = useState(true);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useToast();
 
@@ -49,10 +49,10 @@ export default function Page() {
   };
 
   useEffect(() => {
-    if (!added) return;
+    if (!loading) return;
     setQuestionList(getData());
-    setAdded(false);
-  }, [added]);
+    setLoading(false);
+  }, [loading]);
 
   return (
     <>
@@ -70,17 +70,16 @@ export default function Page() {
           {modalTitle}
         </Button>
       </Flex>
-      {questionList !== undefined && (
-        <Table
-          tableData={questionList}
-          removeRow={removeRow}
-          columns={defaultColumns}
-        />
-      )}
+      <Table
+        isLoading={loading}
+        tableData={questionList}
+        removeRow={removeRow}
+        columns={defaultColumns}
+      />
       <QuestionFormModal
         isOpen={isOpen}
         onClose={onClose}
-        setAdded={setAdded}
+        setLoading={setLoading}
       />
     </>
   );

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
   const toast = useToast();
 
   const removeRow = (id: number) => {
-    deleteQuestionById(id);
+    deleteQuestionById(id + 1);
     setQuestionList(getData());
     toast({
       title: 'Question deleted.',

--- a/frontend/src/app/matching/page.tsx
+++ b/frontend/src/app/matching/page.tsx
@@ -84,7 +84,7 @@ function Page() {
         borderRadius="md"
         boxShadow="lg"
       >
-        <VStack spacing={4} align="center">
+        <VStack spacing={8} align="center">
           <Text textAlign="center" fontSize="xl" fontWeight="bold">
             Choose Matching Difficulty
           </Text>

--- a/frontend/src/components/modal/QuestionFormModal.tsx
+++ b/frontend/src/components/modal/QuestionFormModal.tsx
@@ -10,11 +10,11 @@ import Modal from './Modal';
 function QuestionFormModal({
   isOpen,
   onClose,
-  setAdded,
+  setLoading,
 }: {
   isOpen: boolean;
   onClose: () => void;
-  setAdded: Dispatch<SetStateAction<boolean>>;
+  setLoading: Dispatch<SetStateAction<boolean>>;
 }) {
   const modalTitle = 'Add Question';
   const initialRef = useRef(null);
@@ -37,7 +37,7 @@ function QuestionFormModal({
     };
     try {
       createQuestion(question);
-      setAdded(true);
+      setLoading(true);
       toast({
         title: 'Question added.',
         description: "We've added your question.",

--- a/frontend/src/components/modal/QuestionFormModal.tsx
+++ b/frontend/src/components/modal/QuestionFormModal.tsx
@@ -88,7 +88,7 @@ function QuestionFormModal({
         changeComplexity={(e) =>
           setComplexity(
             QuestionComplexity[
-              e.target.value as keyof typeof QuestionComplexity
+              e.target.value.toUpperCase() as keyof typeof QuestionComplexity
             ],
           )
         }

--- a/frontend/src/components/navBar/NavButton.tsx
+++ b/frontend/src/components/navBar/NavButton.tsx
@@ -1,15 +1,7 @@
 'use client';
 
 import { ReactElement } from 'react';
-import {
-  As,
-  Button,
-  ButtonProps,
-  HStack,
-  Icon,
-  Show,
-  Text,
-} from '@chakra-ui/react';
+import { As, Button, ButtonProps, HStack, Icon, Text } from '@chakra-ui/react';
 
 interface NavButtonProps extends ButtonProps {
   icon: As;
@@ -24,9 +16,7 @@ function NavButton(
     <Button justifyContent="start" variant="ghost" {...buttonProps}>
       <HStack spacing={3}>
         <Icon as={icon} boxSize={6} color="subtle" />
-        <Show above="md">
-          <Text>{label}</Text>
-        </Show>
+        <Text display={{ base: 'none', md: 'undefined' }}>{label}</Text>
       </HStack>
     </Button>
   );

--- a/frontend/src/components/slider/QuestionRangeSlider.tsx
+++ b/frontend/src/components/slider/QuestionRangeSlider.tsx
@@ -38,15 +38,23 @@ export default function QuestionRangeSlider({
     getTrackProps,
   } = useRangeSlider(sliderOptions);
 
-  const { onKeyDown: onThumbKeyDownFirstIndex, ...thumbPropsFirstIndex } =
-    getThumbProps({
-      index: 0,
-    });
+  const {
+    onKeyDown: onThumbKeyDownFirstIndex,
+    // eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]
+    role: roleFirstIndex,
+    ...thumbPropsFirstIndex
+  } = getThumbProps({
+    index: 0,
+  });
 
-  const { onKeyDown: onThumbKeyDownSecondIndex, ...thumbPropsSecondIndex } =
-    getThumbProps({
-      index: 1,
-    });
+  const {
+    onKeyDown: onThumbKeyDownSecondIndex,
+    // eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]
+    role: roleSecondIndex,
+    ...thumbPropsSecondIndex
+  } = getThumbProps({
+    index: 1,
+  });
 
   const markers = [1, 2, 3].map((i) => getMarkerProps({ value: i }));
 

--- a/frontend/src/components/slider/SliderThumb.tsx
+++ b/frontend/src/components/slider/SliderThumb.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react';
+import { Box, useColorModeValue } from '@chakra-ui/react';
 import { KeyboardEvent } from 'react';
 
 type Props = {
@@ -19,11 +19,13 @@ export default function Thumb({
 }: Props) {
   return (
     <Box
-      top="1%"
       boxSize={8}
       bgColor={bgColor}
       borderRadius="full"
-      _focusVisible={{
+      transform="translateX(-50%)"
+      mt={-4}
+      _focus={{
+        backgroundColor: useColorModeValue('teal.800', 'teal.100'),
         outline: 'none',
       }}
       onKeyDown={(e) => {

--- a/frontend/src/components/table/Table.tsx
+++ b/frontend/src/components/table/Table.tsx
@@ -5,6 +5,7 @@ import {
   Table as ChakraTable,
   LinkBox,
   LinkOverlay,
+  Skeleton,
   Tbody,
   Td,
   Text,
@@ -27,6 +28,7 @@ interface TableProps<T extends object> {
   tableData: T[];
   removeRow: (id: number) => void;
   columns: ColumnDef<T, any>[];
+  isLoading?: boolean;
   isSortable?: boolean;
 }
 
@@ -37,10 +39,13 @@ declare module '@tanstack/table-core' {
   }
 }
 
+const skeletonRows = Array.from({ length: 10 });
+
 function Table<T extends object>({
   tableData,
   removeRow,
   columns,
+  isLoading = false,
   isSortable = true,
 }: TableProps<T>) {
   const [sortBy, setSortBy] = useState<SortingState>([]);
@@ -70,6 +75,29 @@ function Table<T extends object>({
           isSortable={isSortable}
         />
         <Tbody>
+          {isLoading
+            ? skeletonRows.map(() => (
+                <Tr>
+                  <Td
+                    textAlign="center"
+                    colSpan={table.getAllColumns().length}
+                    paddingY={3}
+                  >
+                    <Skeleton isLoaded={!isLoading} h="18px" w="100%" />
+                  </Td>
+                </Tr>
+              ))
+            : table.getRowModel().rows.length === 0 && (
+                <Tr>
+                  <Td
+                    textAlign="center"
+                    colSpan={table.getAllColumns().length}
+                    paddingY={8}
+                  >
+                    <Text color="gray.500">No questions found</Text>
+                  </Td>
+                </Tr>
+              )}
           {table.getRowModel().rows.map((row) => (
             <Tr key={row.id}>
               {row.getVisibleCells().map((cell) =>
@@ -93,17 +121,6 @@ function Table<T extends object>({
               )}
             </Tr>
           ))}
-          {table.getRowModel().rows.length === 0 && (
-            <Tr>
-              <Td
-                textAlign="center"
-                colSpan={table.getAllColumns().length}
-                paddingY={8}
-              >
-                <Text color="gray.500">No questions found</Text>
-              </Td>
-            </Tr>
-          )}
         </Tbody>
       </ChakraTable>
     </Card>


### PR DESCRIPTION
The issue is that the style for the navbar, slider and table components is not being prerendered by SSR, and is only applied after React hydrates the page. This means that the navbar, slider, and table will initially be displayed without some of the styling, and they will only appear after a short delay.

The PR aims to fix this issue by changing the components used for the navbar, slider and table. The following changes are proposed:

- Navbar: The current show component from chakra is being replaced with static CSS to render the dark mode toggler's styling. This means that the styling for the dark mode toggler will be prerendered by SSR, and will be displayed immediately when the page loads.
- Slider: The bug is caused by the RangeSliderThumb component's 'role' in its props passed down by the useRangeSlider hook. To fix this bug, the role prop was just removed and some static css was added to ensure correct positioning of the component.
- Table: The current table component is being replaced with a new component that uses a skeleton screen to show a placeholder for the table data while the data is loading. This will ensure that the table is always visible to the user, even before the table data has loaded.