### PR TITLE
Fix: Add Limit on Question Categories Selection

### DIFF
--- a/frontend/src/components/form/AddQuestionForm.tsx
+++ b/frontend/src/components/form/AddQuestionForm.tsx
@@ -7,11 +7,16 @@ import {
   Select as ChakraSelect,
   VStack,
 } from '@chakra-ui/react';
-import { QuestionDifficulty, questionCategories } from '@/types/question';
+import {
+  QuestionCategory,
+  QuestionDifficulty,
+  questionCategories,
+} from '@/types/question';
 import { ChangeEvent, MutableRefObject } from 'react';
 import { Select } from 'chakra-react-select';
 
 interface AddQuestionFormProps {
+  categories: QuestionCategory[];
   changeTitle: (e: ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: ChangeEvent<HTMLInputElement>) => void;
   changeCategories: (newValue) => void;
@@ -21,8 +26,8 @@ interface AddQuestionFormProps {
 }
 
 interface CategoryOption {
-  label: string;
-  value: string;
+  label: QuestionCategory;
+  value: QuestionCategory;
 }
 
 const categoryOptions: CategoryOption[] = questionCategories.map(
@@ -34,6 +39,7 @@ const categoryOptions: CategoryOption[] = questionCategories.map(
 
 function AddQuestionForm({
   initialRef,
+  categories,
   changeCategories,
   changeDifficulty,
   changeDescription,
@@ -71,6 +77,7 @@ function AddQuestionForm({
           colorScheme="blue"
           options={categoryOptions}
           placeholder="Select categories"
+          isOptionDisabled={() => categories.length >= 5}
           closeMenuOnSelect={false}
           onChange={changeCategories}
         />

--- a/frontend/src/components/modal/AddQuestionFormModal.tsx
+++ b/frontend/src/components/modal/AddQuestionFormModal.tsx
@@ -13,8 +13,8 @@ import Modal from './Modal';
 import AddQuestionForm from '../form/AddQuestionForm';
 
 interface CategoryOption {
-  label: string;
-  value: string;
+  label: QuestionCategory;
+  value: QuestionCategory;
 }
 
 function AddQuestionFormModal({
@@ -41,7 +41,7 @@ function AddQuestionFormModal({
   );
 
   const changeCategories = (newValues: CategoryOption[]) => {
-    setCat(newValues.map((option) => option.value as QuestionCategory));
+    setCat(newValues.map((option) => option.value));
   };
 
   const handleSubmit = () => {
@@ -82,6 +82,7 @@ function AddQuestionFormModal({
     >
       <AddQuestionForm
         initialRef={initialRef}
+        categories={cat}
         changeCategories={changeCategories}
         changeDifficulty={(e) =>
           setDifficulty(e.target.value as QuestionDifficulty)


### PR DESCRIPTION
This pull request addresses an issue where maintainers can select an unlimited number of categories for questions. To maintain consistency and usability, this PR introduces a limit that restricts maintainers from selecting more than 5 categories for a question.

**Changes Made:**

- Added a validation check in the question creation form to ensure that maintainers cannot select more than 5 categories.
- When 5 categories are selected, all options are disabled to prevent maintainers from selecting any more.