### PR TITLE
Resolve issue where the message trigger update of GKE occurs before the images are pushed to Artifact Registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -187,8 +187,6 @@ steps:
       - '-t'
       - 'gcr.io/$PROJECT_ID/frontend_service'
       - ./frontend
-    # Add any other Docker build options as needed.
-
   # Step 3: Delete the .env file
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -196,7 +194,14 @@ steps:
       - '-c'
       - |
         rm frontend/.env
-  # Trigger update of images in deployed to GKE
+  # Trigger update of images used in deployment to GKE
+  images:
+    - 'gcr.io/$PROJECT_ID/question_service:latest'
+    - 'gcr.io/$PROJECT_ID/matching_service:latest'
+    - 'gcr.io/$PROJECT_ID/user_service:latest'
+    - 'gcr.io/$PROJECT_ID/room_service:latest'
+    - 'gcr.io/$PROJECT_ID/video_token_service:latest'
+    - 'gcr.io/$PROJECT_ID/frontend_service:latest'
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
@@ -207,10 +212,3 @@ steps:
         else
           echo "Build steps failed, not publishing Pub/Sub message."
         fi
-images:
-  - 'gcr.io/$PROJECT_ID/question_service:latest'
-  - 'gcr.io/$PROJECT_ID/matching_service:latest'
-  - 'gcr.io/$PROJECT_ID/user_service:latest'
-  - 'gcr.io/$PROJECT_ID/room_service:latest'
-  - 'gcr.io/$PROJECT_ID/video_token_service:latest'
-  - 'gcr.io/$PROJECT_ID/frontend_service:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,6 +35,11 @@ steps:
       - '-c'
       - |
         rm backend/question_service/.env
+# Push question image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/question_service:latest'
 # Matching Service
   # Step 1: Create the .env file in backend/matching_service/
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -187,6 +187,8 @@ steps:
       - '-t'
       - 'gcr.io/$PROJECT_ID/frontend_service'
       - ./frontend
+    # Add any other Docker build options as needed.
+
   # Step 3: Delete the .env file
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -194,14 +196,7 @@ steps:
       - '-c'
       - |
         rm frontend/.env
-  # Trigger update of images used in deployment to GKE
-  images:
-    - 'gcr.io/$PROJECT_ID/question_service:latest'
-    - 'gcr.io/$PROJECT_ID/matching_service:latest'
-    - 'gcr.io/$PROJECT_ID/user_service:latest'
-    - 'gcr.io/$PROJECT_ID/room_service:latest'
-    - 'gcr.io/$PROJECT_ID/video_token_service:latest'
-    - 'gcr.io/$PROJECT_ID/frontend_service:latest'
+  # Trigger update of images in deployed to GKE
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
@@ -212,3 +207,10 @@ steps:
         else
           echo "Build steps failed, not publishing Pub/Sub message."
         fi
+images:
+  - 'gcr.io/$PROJECT_ID/question_service:latest'
+  - 'gcr.io/$PROJECT_ID/matching_service:latest'
+  - 'gcr.io/$PROJECT_ID/user_service:latest'
+  - 'gcr.io/$PROJECT_ID/room_service:latest'
+  - 'gcr.io/$PROJECT_ID/video_token_service:latest'
+  - 'gcr.io/$PROJECT_ID/frontend_service:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -197,7 +197,6 @@ steps:
       - |
         rm frontend/.env
   # Push all images
-  steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -224,16 +224,6 @@ steps:
     args:
       - 'push'
       - 'gcr.io/$PROJECT_ID/frontend_service:latest'
-  # Push all images
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'push'
-      - 'gcr.io/$PROJECT_ID/question_service:latest'
-      - 'gcr.io/$PROJECT_ID/matching_service:latest'
-      - 'gcr.io/$PROJECT_ID/user_service:latest'
-      - 'gcr.io/$PROJECT_ID/room_service:latest'
-      - 'gcr.io/$PROJECT_ID/video_token_service:latest'
-      - 'gcr.io/$PROJECT_ID/frontend_service:latest'
   # Trigger update of images in deployed to GKE
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -196,6 +196,17 @@ steps:
       - '-c'
       - |
         rm frontend/.env
+  # Push all images
+  steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/question_service:latest'
+      - 'gcr.io/$PROJECT_ID/matching_service:latest'
+      - 'gcr.io/$PROJECT_ID/user_service:latest'
+      - 'gcr.io/$PROJECT_ID/room_service:latest'
+      - 'gcr.io/$PROJECT_ID/video_token_service:latest'
+      - 'gcr.io/$PROJECT_ID/frontend_service:latest'
   # Trigger update of images in deployed to GKE
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -207,10 +218,10 @@ steps:
         else
           echo "Build steps failed, not publishing Pub/Sub message."
         fi
-images:
-  - 'gcr.io/$PROJECT_ID/question_service:latest'
-  - 'gcr.io/$PROJECT_ID/matching_service:latest'
-  - 'gcr.io/$PROJECT_ID/user_service:latest'
-  - 'gcr.io/$PROJECT_ID/room_service:latest'
-  - 'gcr.io/$PROJECT_ID/video_token_service:latest'
-  - 'gcr.io/$PROJECT_ID/frontend_service:latest'
+# images:
+#   - 'gcr.io/$PROJECT_ID/question_service:latest'
+#   - 'gcr.io/$PROJECT_ID/matching_service:latest'
+#   - 'gcr.io/$PROJECT_ID/user_service:latest'
+#   - 'gcr.io/$PROJECT_ID/room_service:latest'
+#   - 'gcr.io/$PROJECT_ID/video_token_service:latest'
+#   - 'gcr.io/$PROJECT_ID/frontend_service:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - '-c'
       - |
         rm backend/question_service/.env
-# Push question image
+  # Step 6: Push question_service image
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
@@ -77,6 +77,11 @@ steps:
       - '-c'
       - |
         rm backend/matching_service/.env
+  # Step 6: Push matching_service image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/matching_service:latest'
 #User Service
   # Step 1: Create the .env file in backend/user_service/
   - name: 'gcr.io/cloud-builders/gcloud'
@@ -114,6 +119,11 @@ steps:
       - '-c'
       - |
         rm backend/user_service/.env
+  # Step 6: Push user_service image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/user_service:latest'
 #Room Service
   # Step 1: Create the .env file in backend/room_service/
   - name: 'gcr.io/cloud-builders/gcloud'
@@ -145,6 +155,11 @@ steps:
       - '-c'
       - |
         rm backend/room_service/.env
+  # Step 5: Push room_service image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/room_service:latest'
 #Video Token Service
   # Step 1: Create the .env file in backend/video_token_service/
   - name: 'gcr.io/cloud-builders/gcloud'
@@ -176,6 +191,11 @@ steps:
       - '-c'
       - |
         rm backend/video_token_service/.env
+  # Step 5: Push video_token_service image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/video_token_service:latest'
 # Frontend service
   # Step 1: Create the .env file in /frontend
   - name: 'gcr.io/cloud-builders/gcloud'
@@ -192,8 +212,6 @@ steps:
       - '-t'
       - 'gcr.io/$PROJECT_ID/frontend_service'
       - ./frontend
-    # Add any other Docker build options as needed.
-
   # Step 3: Delete the .env file
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -201,6 +219,11 @@ steps:
       - '-c'
       - |
         rm frontend/.env
+  # Step 4: Push frontend_service image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/frontend_service:latest'
   # Push all images
   - name: 'gcr.io/cloud-builders/docker'
     args:
@@ -222,10 +245,3 @@ steps:
         else
           echo "Build steps failed, not publishing Pub/Sub message."
         fi
-# images:
-#   - 'gcr.io/$PROJECT_ID/question_service:latest'
-#   - 'gcr.io/$PROJECT_ID/matching_service:latest'
-#   - 'gcr.io/$PROJECT_ID/user_service:latest'
-#   - 'gcr.io/$PROJECT_ID/room_service:latest'
-#   - 'gcr.io/$PROJECT_ID/video_token_service:latest'
-#   - 'gcr.io/$PROJECT_ID/frontend_service:latest'


### PR DESCRIPTION
Resolve issue where the message trigger update of GKE occurs before the images are pushed to Artifact Registry.  This means that orginally, the previous version of images are pulled and updated into the cluster when a new build occurs